### PR TITLE
Engage CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,23 @@
+version: 2
+
+jobs:
+  build:
+    docker:
+      - image: perl:5.28.1
+    steps:
+      - checkout
+      - run:
+          name: "Install CPAN dependencies"
+          command: |
+            export PERL_MM_USE_DEFAULT=1
+            cpan DateTime
+            cpan File::Slurp
+            cpan Moose
+            cpan Moose::Role
+            cpan namespace::autoclean
+            cpan Try::Tiny
+            cpan Test::Exception
+      - run:
+          name: "Run Test Suite"
+          command: |
+            prove -lr t

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 x12-schema
 ==========
+
+### Running Tests
+
+From the base directory of the repository:
+
+    prove -lr t


### PR DESCRIPTION
Add a basic CircleCI configuration.

CPAN dependencies are hard-coded into the config, because the `Makefile.PL` doesn't work without the `inc` directory containing Module::Install-related materials.